### PR TITLE
Scaffold clean-architecture financial planner backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**/bin
+**/obj
+.git
+.gitignore
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
+WORKDIR /src
+
+COPY FinancialPlanner.slnx ./
+COPY FinancialPlanner.Api/FinancialPlanner.Api.csproj FinancialPlanner.Api/
+COPY FinancialPlanner.Application/FinancialPlanner.Application.csproj FinancialPlanner.Application/
+COPY FinancialPlanner.Domain/FinancialPlanner.Domain.csproj FinancialPlanner.Domain/
+COPY FinancialPlanner.Infrastructure/FinancialPlanner.Infrastructure.csproj FinancialPlanner.Infrastructure/
+COPY FinancialPlanner.Contracts/FinancialPlanner.Contracts.csproj FinancialPlanner.Contracts/
+
+RUN dotnet restore FinancialPlanner.Api/FinancialPlanner.Api.csproj
+
+COPY . .
+RUN dotnet publish FinancialPlanner.Api/FinancialPlanner.Api.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "FinancialPlanner.Api.dll"]

--- a/FinancialPlanner.Api/Common/Middleware/ExceptionHandlingMiddleware.cs
+++ b/FinancialPlanner.Api/Common/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,50 @@
+using FinancialPlanner.Application.Common.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinancialPlanner.Api.Common.Middleware;
+
+public sealed class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        try
+        {
+            await next(context);
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Unhandled exception. CorrelationId: {CorrelationId}", context.TraceIdentifier);
+            await WriteProblemDetailsAsync(context, exception);
+        }
+    }
+
+    private static async Task WriteProblemDetailsAsync(HttpContext context, Exception exception)
+    {
+        var (status, title) = exception switch
+        {
+            ValidationException => (StatusCodes.Status400BadRequest, "Validation error"),
+            NotFoundException => (StatusCodes.Status404NotFound, "Resource not found"),
+            InvalidOperationException => (StatusCodes.Status400BadRequest, "Business rule violation"),
+            _ => (StatusCodes.Status500InternalServerError, "Server error")
+        };
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = status,
+            Title = title,
+            Detail = exception.Message,
+            Extensions =
+            {
+                ["correlationId"] = context.TraceIdentifier
+            }
+        };
+
+        if (exception is ValidationException validationException)
+        {
+            problemDetails.Extensions["errors"] = validationException.Errors;
+        }
+
+        context.Response.StatusCode = status;
+        await context.Response.WriteAsJsonAsync(problemDetails);
+    }
+}

--- a/FinancialPlanner.Api/Controllers/AuthController.cs
+++ b/FinancialPlanner.Api/Controllers/AuthController.cs
@@ -1,0 +1,25 @@
+using FinancialPlanner.Application.Authentication.Commands.Login;
+using FinancialPlanner.Application.Authentication.Commands.Register;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinancialPlanner.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public sealed class AuthController(ISender sender) : ControllerBase
+{
+    [HttpPost("register")]
+    public async Task<IActionResult> Register([FromBody] RegisterCommand command, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    [HttpPost("login")]
+    public async Task<IActionResult> Login([FromBody] LoginCommand command, CancellationToken cancellationToken)
+    {
+        var result = await sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+}

--- a/FinancialPlanner.Api/Controllers/ExpensesController.cs
+++ b/FinancialPlanner.Api/Controllers/ExpensesController.cs
@@ -1,0 +1,39 @@
+using System.Security.Claims;
+using FinancialPlanner.Application.Expenses.Commands.CreateExpense;
+using FinancialPlanner.Application.Expenses.Queries.GetExpenses;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinancialPlanner.Api.Controllers;
+
+[ApiController]
+[Route("api/expenses")]
+[Authorize]
+public sealed class ExpensesController(ISender sender) : ControllerBase
+{
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateExpenseCommand command, CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        var expenseId = await sender.Send(command with { UserId = userId }, cancellationToken);
+        return Ok(new { expenseId });
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> List(CancellationToken cancellationToken)
+    {
+        var userId = GetUserId();
+        var result = await sender.Send(new GetExpensesQuery(userId), cancellationToken);
+        return Ok(result);
+    }
+
+    private Guid GetUserId()
+    {
+        var value = User.FindFirstValue(ClaimTypes.NameIdentifier)
+                    ?? User.FindFirstValue(ClaimTypes.Name)
+                    ?? throw new UnauthorizedAccessException("User identifier claim was not found.");
+
+        return Guid.Parse(value);
+    }
+}

--- a/FinancialPlanner.Api/FinancialPlanner.Api.csproj
+++ b/FinancialPlanner.Api/FinancialPlanner.Api.csproj
@@ -8,6 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FinancialPlanner.Api/Program.cs
+++ b/FinancialPlanner.Api/Program.cs
@@ -1,41 +1,39 @@
+using FinancialPlanner.Api.Common.Middleware;
+using FinancialPlanner.Application.DependencyInjection;
+using Serilog;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Host.UseSerilog((context, loggerConfiguration) =>
+{
+    loggerConfiguration
+        .ReadFrom.Configuration(context.Configuration)
+        .Enrich.FromLogContext()
+        .Enrich.WithProperty("Application", "FinancialPlanner.Api")
+        .WriteTo.Console();
+});
+
+builder.Services.AddApplication();
+builder.Services.AddInfrastructureViaReflection(builder.Configuration);
+builder.Services.AddControllers();
+builder.Services.AddProblemDetails();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
+app.UseSerilogRequestLogging();
+app.UseMiddleware<ExceptionHandlingMiddleware>();
+app.UseHttpsRedirection();
+app.UseAuthentication();
+app.UseAuthorization();
+
 if (app.Environment.IsDevelopment())
 {
-    app.MapOpenApi();
+    app.UseSwagger();
+    app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapControllers();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/FinancialPlanner.Api/appsettings.json
+++ b/FinancialPlanner.Api/appsettings.json
@@ -1,9 +1,29 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=postgres;Port=5432;Database=financial_planner;Username=postgres;Password=postgres"
+  },
+  "Jwt": {
+    "Secret": "CHANGE_ME_TO_A_LONG_RANDOM_KEY_AT_LEAST_32_CHARS",
+    "Issuer": "FinancialPlanner",
+    "Audience": "FinancialPlanner.Api"
+  },
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] [{CorrelationId}] {Message:lj}{NewLine}{Exception}"
+        }
+      }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/FinancialPlanner.Application/Abstractions/Authentication/IJwtTokenGenerator.cs
+++ b/FinancialPlanner.Application/Abstractions/Authentication/IJwtTokenGenerator.cs
@@ -1,0 +1,8 @@
+namespace FinancialPlanner.Application.Abstractions.Authentication;
+
+public interface IJwtTokenGenerator
+{
+    string GenerateToken(Guid userId, string email);
+
+    string GenerateRefreshToken();
+}

--- a/FinancialPlanner.Application/Abstractions/Authentication/IPasswordHasher.cs
+++ b/FinancialPlanner.Application/Abstractions/Authentication/IPasswordHasher.cs
@@ -1,0 +1,8 @@
+namespace FinancialPlanner.Application.Abstractions.Authentication;
+
+public interface IPasswordHasher
+{
+    string Hash(string password);
+
+    bool Verify(string password, string passwordHash);
+}

--- a/FinancialPlanner.Application/Abstractions/Persistence/IExpenseRepository.cs
+++ b/FinancialPlanner.Application/Abstractions/Persistence/IExpenseRepository.cs
@@ -1,0 +1,10 @@
+using FinancialPlanner.Domain.Entities;
+
+namespace FinancialPlanner.Application.Abstractions.Persistence;
+
+public interface IExpenseRepository
+{
+    Task AddAsync(Expense expense, CancellationToken cancellationToken);
+
+    Task<IReadOnlyCollection<Expense>> ListByUserIdAsync(Guid userId, CancellationToken cancellationToken);
+}

--- a/FinancialPlanner.Application/Abstractions/Persistence/IRefreshTokenRepository.cs
+++ b/FinancialPlanner.Application/Abstractions/Persistence/IRefreshTokenRepository.cs
@@ -1,0 +1,8 @@
+using FinancialPlanner.Domain.Entities;
+
+namespace FinancialPlanner.Application.Abstractions.Persistence;
+
+public interface IRefreshTokenRepository
+{
+    Task AddAsync(RefreshToken refreshToken, CancellationToken cancellationToken);
+}

--- a/FinancialPlanner.Application/Abstractions/Persistence/IUnitOfWork.cs
+++ b/FinancialPlanner.Application/Abstractions/Persistence/IUnitOfWork.cs
@@ -1,0 +1,6 @@
+namespace FinancialPlanner.Application.Abstractions.Persistence;
+
+public interface IUnitOfWork
+{
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/FinancialPlanner.Application/Abstractions/Persistence/IUserRepository.cs
+++ b/FinancialPlanner.Application/Abstractions/Persistence/IUserRepository.cs
@@ -1,0 +1,12 @@
+using FinancialPlanner.Domain.Entities;
+
+namespace FinancialPlanner.Application.Abstractions.Persistence;
+
+public interface IUserRepository
+{
+    Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken);
+
+    Task<User?> GetByIdAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task AddAsync(User user, CancellationToken cancellationToken);
+}

--- a/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommand.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Login;
+
+public sealed record LoginCommand(string Email, string Password) : IRequest<LoginResponse>;
+
+public sealed record LoginResponse(string AccessToken, string RefreshToken, Guid UserId);

--- a/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommandHandler.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommandHandler.cs
@@ -1,0 +1,38 @@
+using FinancialPlanner.Application.Abstractions.Authentication;
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Domain.Entities;
+using FinancialPlanner.Domain.ValueObjects;
+using MediatR;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Login;
+
+public sealed class LoginCommandHandler(
+    IUserRepository userRepository,
+    IRefreshTokenRepository refreshTokenRepository,
+    IPasswordHasher passwordHasher,
+    IJwtTokenGenerator jwtTokenGenerator,
+    IUnitOfWork unitOfWork) : IRequestHandler<LoginCommand, LoginResponse>
+{
+    public async Task<LoginResponse> Handle(LoginCommand request, CancellationToken cancellationToken)
+    {
+        var email = Email.Create(request.Email).Value;
+        var user = await userRepository.GetByEmailAsync(email, cancellationToken)
+            ?? throw new InvalidOperationException("Invalid credentials.");
+
+        if (!passwordHasher.Verify(request.Password, user.PasswordHash))
+        {
+            throw new InvalidOperationException("Invalid credentials.");
+        }
+
+        var refreshTokenValue = jwtTokenGenerator.GenerateRefreshToken();
+        var refreshToken = RefreshToken.Create(user.Id, refreshTokenValue, DateTime.UtcNow.AddDays(7));
+        await refreshTokenRepository.AddAsync(refreshToken, cancellationToken);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new LoginResponse(
+            jwtTokenGenerator.GenerateToken(user.Id, user.Email.Value),
+            refreshTokenValue,
+            user.Id);
+    }
+}

--- a/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommandValidator.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Login/LoginCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Login;
+
+public sealed class LoginCommandValidator : AbstractValidator<LoginCommand>
+{
+    public LoginCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty();
+    }
+}

--- a/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommand.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Register;
+
+public sealed record RegisterCommand(string Email, string Password) : IRequest<AuthResponse>;
+
+public sealed record AuthResponse(string AccessToken, string RefreshToken, Guid UserId);

--- a/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommandHandler.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommandHandler.cs
@@ -1,0 +1,39 @@
+using FinancialPlanner.Application.Abstractions.Authentication;
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Domain.Entities;
+using FinancialPlanner.Domain.ValueObjects;
+using MediatR;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Register;
+
+public sealed class RegisterCommandHandler(
+    IUserRepository userRepository,
+    IRefreshTokenRepository refreshTokenRepository,
+    IPasswordHasher passwordHasher,
+    IJwtTokenGenerator jwtTokenGenerator,
+    IUnitOfWork unitOfWork) : IRequestHandler<RegisterCommand, AuthResponse>
+{
+    public async Task<AuthResponse> Handle(RegisterCommand request, CancellationToken cancellationToken)
+    {
+        var normalizedEmail = Email.Create(request.Email).Value;
+        var existingUser = await userRepository.GetByEmailAsync(normalizedEmail, cancellationToken);
+        if (existingUser is not null)
+        {
+            throw new InvalidOperationException("A user with this email already exists.");
+        }
+
+        var user = User.Create(Email.Create(request.Email), passwordHasher.Hash(request.Password));
+        await userRepository.AddAsync(user, cancellationToken);
+
+        var refreshTokenValue = jwtTokenGenerator.GenerateRefreshToken();
+        var refreshToken = RefreshToken.Create(user.Id, refreshTokenValue, DateTime.UtcNow.AddDays(7));
+        await refreshTokenRepository.AddAsync(refreshToken, cancellationToken);
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return new AuthResponse(
+            jwtTokenGenerator.GenerateToken(user.Id, user.Email.Value),
+            refreshTokenValue,
+            user.Id);
+    }
+}

--- a/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommandValidator.cs
+++ b/FinancialPlanner.Application/Authentication/Commands/Register/RegisterCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace FinancialPlanner.Application.Authentication.Commands.Register;
+
+public sealed class RegisterCommandValidator : AbstractValidator<RegisterCommand>
+{
+    public RegisterCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().EmailAddress();
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(8);
+    }
+}

--- a/FinancialPlanner.Application/Class1.cs
+++ b/FinancialPlanner.Application/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace FinancialPlanner.Application
-{
-    public class Class1
-    {
-
-    }
-}

--- a/FinancialPlanner.Application/Common/Behaviors/ValidationBehavior.cs
+++ b/FinancialPlanner.Application/Common/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using MediatR;
+using ValidationException = FinancialPlanner.Application.Common.Exceptions.ValidationException;
+
+namespace FinancialPlanner.Application.Common.Behaviors;
+
+public sealed class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!validators.Any())
+        {
+            return await next();
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+        var validationResults = await Task.WhenAll(validators.Select(v => v.ValidateAsync(context, cancellationToken)));
+
+        var errors = validationResults
+            .Where(vr => !vr.IsValid)
+            .SelectMany(vr => vr.Errors)
+            .GroupBy(e => e.PropertyName)
+            .ToDictionary(g => g.Key, g => g.Select(e => e.ErrorMessage).Distinct().ToArray());
+
+        if (errors.Count != 0)
+        {
+            throw new ValidationException(errors);
+        }
+
+        return await next();
+    }
+}

--- a/FinancialPlanner.Application/Common/Exceptions/NotFoundException.cs
+++ b/FinancialPlanner.Application/Common/Exceptions/NotFoundException.cs
@@ -1,0 +1,3 @@
+namespace FinancialPlanner.Application.Common.Exceptions;
+
+public sealed class NotFoundException(string message) : Exception(message);

--- a/FinancialPlanner.Application/Common/Exceptions/ValidationException.cs
+++ b/FinancialPlanner.Application/Common/Exceptions/ValidationException.cs
@@ -1,0 +1,7 @@
+namespace FinancialPlanner.Application.Common.Exceptions;
+
+public sealed class ValidationException(IReadOnlyDictionary<string, string[]> errors)
+    : Exception("One or more validation failures occurred.")
+{
+    public IReadOnlyDictionary<string, string[]> Errors { get; } = errors;
+}

--- a/FinancialPlanner.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/FinancialPlanner.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using System.Reflection;
+using FinancialPlanner.Application.Common.Behaviors;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FinancialPlanner.Application.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        services.AddMediatR(typeof(ServiceCollectionExtensions).Assembly);
+        services.AddValidatorsFromAssembly(typeof(ServiceCollectionExtensions).Assembly);
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+
+        return services;
+    }
+
+    public static IServiceCollection AddInfrastructureViaReflection(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var infrastructureAssembly = Assembly.Load("FinancialPlanner.Infrastructure");
+        var extensionType = infrastructureAssembly.GetType("FinancialPlanner.Infrastructure.DependencyInjection.ServiceCollectionExtensions")
+            ?? throw new InvalidOperationException("Infrastructure DI extension type was not found.");
+
+        var method = extensionType.GetMethod("AddInfrastructure", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("AddInfrastructure method was not found.");
+
+        method.Invoke(null, [services, configuration]);
+        return services;
+    }
+}

--- a/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommand.cs
+++ b/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace FinancialPlanner.Application.Expenses.Commands.CreateExpense;
+
+public sealed record CreateExpenseCommand(Guid UserId, decimal Amount, string Category, DateTime OccurredAtUtc, string? Note)
+    : IRequest<Guid>;

--- a/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommandHandler.cs
+++ b/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommandHandler.cs
@@ -1,0 +1,33 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Application.Common.Exceptions;
+using FinancialPlanner.Domain.Entities;
+using MediatR;
+
+namespace FinancialPlanner.Application.Expenses.Commands.CreateExpense;
+
+public sealed class CreateExpenseCommandHandler(
+    IUserRepository userRepository,
+    IExpenseRepository expenseRepository,
+    IUnitOfWork unitOfWork) : IRequestHandler<CreateExpenseCommand, Guid>
+{
+    public async Task<Guid> Handle(CreateExpenseCommand request, CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(request.UserId, cancellationToken);
+        if (user is null)
+        {
+            throw new NotFoundException("User not found.");
+        }
+
+        var expense = Expense.Create(
+            request.UserId,
+            request.Amount,
+            request.Category,
+            request.OccurredAtUtc == default ? DateTime.UtcNow : request.OccurredAtUtc,
+            request.Note);
+
+        await expenseRepository.AddAsync(expense, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        return expense.Id;
+    }
+}

--- a/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommandValidator.cs
+++ b/FinancialPlanner.Application/Expenses/Commands/CreateExpense/CreateExpenseCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace FinancialPlanner.Application.Expenses.Commands.CreateExpense;
+
+public sealed class CreateExpenseCommandValidator : AbstractValidator<CreateExpenseCommand>
+{
+    public CreateExpenseCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEqual(Guid.Empty);
+        RuleFor(x => x.Amount).GreaterThan(0);
+        RuleFor(x => x.Category).NotEmpty().MaximumLength(100);
+    }
+}

--- a/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQuery.cs
+++ b/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQuery.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace FinancialPlanner.Application.Expenses.Queries.GetExpenses;
+
+public sealed record GetExpensesQuery(Guid UserId) : IRequest<IReadOnlyCollection<ExpenseDto>>;
+
+public sealed record ExpenseDto(Guid Id, decimal Amount, string Category, DateTime OccurredAtUtc, string? Note);

--- a/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQueryHandler.cs
+++ b/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQueryHandler.cs
@@ -1,0 +1,18 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+using MediatR;
+
+namespace FinancialPlanner.Application.Expenses.Queries.GetExpenses;
+
+public sealed class GetExpensesQueryHandler(IExpenseRepository expenseRepository)
+    : IRequestHandler<GetExpensesQuery, IReadOnlyCollection<ExpenseDto>>
+{
+    public async Task<IReadOnlyCollection<ExpenseDto>> Handle(GetExpensesQuery request, CancellationToken cancellationToken)
+    {
+        var expenses = await expenseRepository.ListByUserIdAsync(request.UserId, cancellationToken);
+
+        return expenses
+            .OrderByDescending(e => e.OccurredAtUtc)
+            .Select(e => new ExpenseDto(e.Id, e.Amount, e.Category, e.OccurredAtUtc, e.Note))
+            .ToArray();
+    }
+}

--- a/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQueryValidator.cs
+++ b/FinancialPlanner.Application/Expenses/Queries/GetExpenses/GetExpensesQueryValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace FinancialPlanner.Application.Expenses.Queries.GetExpenses;
+
+public sealed class GetExpensesQueryValidator : AbstractValidator<GetExpensesQuery>
+{
+    public GetExpensesQueryValidator()
+    {
+        RuleFor(x => x.UserId).NotEqual(Guid.Empty);
+    }
+}

--- a/FinancialPlanner.Application/FinancialPlanner.Application.csproj
+++ b/FinancialPlanner.Application/FinancialPlanner.Application.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -8,6 +8,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FinancialPlanner.Domain\FinancialPlanner.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.0" />
+    <PackageReference Include="MediatR" Version="11.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/FinancialPlanner.Contracts/Authentication/LoginRequest.cs
+++ b/FinancialPlanner.Contracts/Authentication/LoginRequest.cs
@@ -1,0 +1,3 @@
+namespace FinancialPlanner.Contracts.Authentication;
+
+public sealed record LoginRequest(string Email, string Password);

--- a/FinancialPlanner.Contracts/Authentication/RegisterRequest.cs
+++ b/FinancialPlanner.Contracts/Authentication/RegisterRequest.cs
@@ -1,0 +1,3 @@
+namespace FinancialPlanner.Contracts.Authentication;
+
+public sealed record RegisterRequest(string Email, string Password);

--- a/FinancialPlanner.Contracts/Expenses/CreateExpenseRequest.cs
+++ b/FinancialPlanner.Contracts/Expenses/CreateExpenseRequest.cs
@@ -1,0 +1,3 @@
+namespace FinancialPlanner.Contracts.Expenses;
+
+public sealed record CreateExpenseRequest(decimal Amount, string Category, DateTime OccurredAtUtc, string? Note);

--- a/FinancialPlanner.Contracts/Expenses/ExpenseResponse.cs
+++ b/FinancialPlanner.Contracts/Expenses/ExpenseResponse.cs
@@ -1,0 +1,3 @@
+namespace FinancialPlanner.Contracts.Expenses;
+
+public sealed record ExpenseResponse(Guid Id, decimal Amount, string Category, DateTime OccurredAtUtc, string? Note);

--- a/FinancialPlanner.Domain/Common/Entity.cs
+++ b/FinancialPlanner.Domain/Common/Entity.cs
@@ -1,0 +1,6 @@
+namespace FinancialPlanner.Domain.Common;
+
+public abstract class Entity
+{
+    public Guid Id { get; protected set; }
+}

--- a/FinancialPlanner.Domain/Entities/Expense.cs
+++ b/FinancialPlanner.Domain/Entities/Expense.cs
@@ -1,0 +1,60 @@
+using FinancialPlanner.Domain.Common;
+
+namespace FinancialPlanner.Domain.Entities;
+
+public sealed class Expense : Entity
+{
+    private Expense()
+    {
+    }
+
+    private Expense(Guid id, Guid userId, decimal amount, string category, DateTime occurredAtUtc, string? note)
+    {
+        Id = id;
+        UserId = userId;
+        SetAmount(amount);
+        SetCategory(category);
+        OccurredAtUtc = occurredAtUtc;
+        Note = note?.Trim();
+    }
+
+    public Guid UserId { get; private set; }
+
+    public decimal Amount { get; private set; }
+
+    public string Category { get; private set; } = string.Empty;
+
+    public DateTime OccurredAtUtc { get; private set; }
+
+    public string? Note { get; private set; }
+
+    public static Expense Create(Guid userId, decimal amount, string category, DateTime occurredAtUtc, string? note)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId must be provided.", nameof(userId));
+        }
+
+        return new Expense(Guid.NewGuid(), userId, amount, category, occurredAtUtc, note);
+    }
+
+    private void SetAmount(decimal amount)
+    {
+        if (amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount), "Expense amount must be greater than zero.");
+        }
+
+        Amount = amount;
+    }
+
+    private void SetCategory(string category)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            throw new ArgumentException("Category is required.", nameof(category));
+        }
+
+        Category = category.Trim();
+    }
+}

--- a/FinancialPlanner.Domain/Entities/RefreshToken.cs
+++ b/FinancialPlanner.Domain/Entities/RefreshToken.cs
@@ -1,0 +1,46 @@
+using FinancialPlanner.Domain.Common;
+
+namespace FinancialPlanner.Domain.Entities;
+
+public sealed class RefreshToken : Entity
+{
+    private RefreshToken()
+    {
+    }
+
+    private RefreshToken(Guid id, Guid userId, string token, DateTime expiresAtUtc)
+    {
+        Id = id;
+        UserId = userId;
+        Token = token;
+        ExpiresAtUtc = expiresAtUtc;
+    }
+
+    public Guid UserId { get; private set; }
+
+    public string Token { get; private set; } = string.Empty;
+
+    public DateTime ExpiresAtUtc { get; private set; }
+
+    public bool IsExpired(DateTime utcNow) => utcNow >= ExpiresAtUtc;
+
+    public static RefreshToken Create(Guid userId, string token, DateTime expiresAtUtc)
+    {
+        if (userId == Guid.Empty)
+        {
+            throw new ArgumentException("UserId must be provided.", nameof(userId));
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException("Refresh token must be provided.", nameof(token));
+        }
+
+        if (expiresAtUtc <= DateTime.UtcNow)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expiresAtUtc), "Refresh token expiry must be in the future.");
+        }
+
+        return new RefreshToken(Guid.NewGuid(), userId, token, expiresAtUtc);
+    }
+}

--- a/FinancialPlanner.Domain/Entities/User.cs
+++ b/FinancialPlanner.Domain/Entities/User.cs
@@ -1,0 +1,41 @@
+using FinancialPlanner.Domain.Common;
+using FinancialPlanner.Domain.ValueObjects;
+
+namespace FinancialPlanner.Domain.Entities;
+
+public sealed class User : Entity
+{
+    private readonly List<RefreshToken> _refreshTokens = [];
+
+    private User()
+    {
+    }
+
+    private User(Guid id, Email email, string passwordHash)
+    {
+        Id = id;
+        Email = email;
+        PasswordHash = passwordHash;
+    }
+
+    public Email Email { get; private set; } = Email.Create("placeholder@example.com");
+
+    public string PasswordHash { get; private set; } = string.Empty;
+
+    public IReadOnlyCollection<RefreshToken> RefreshTokens => _refreshTokens;
+
+    public static User Create(Email email, string passwordHash)
+    {
+        if (string.IsNullOrWhiteSpace(passwordHash))
+        {
+            throw new ArgumentException("Password hash cannot be empty.", nameof(passwordHash));
+        }
+
+        return new User(Guid.NewGuid(), email, passwordHash);
+    }
+
+    public void AddRefreshToken(string token, DateTime expiresAt)
+    {
+        _refreshTokens.Add(RefreshToken.Create(Id, token, expiresAt));
+    }
+}

--- a/FinancialPlanner.Domain/ValueObjects/Email.cs
+++ b/FinancialPlanner.Domain/ValueObjects/Email.cs
@@ -1,0 +1,23 @@
+namespace FinancialPlanner.Domain.ValueObjects;
+
+public sealed class Email
+{
+    public string Value { get; }
+
+    private Email(string value)
+    {
+        Value = value;
+    }
+
+    public static Email Create(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input) || !input.Contains('@'))
+        {
+            throw new ArgumentException("Invalid email format.", nameof(input));
+        }
+
+        return new Email(input.Trim().ToLowerInvariant());
+    }
+
+    public override string ToString() => Value;
+}

--- a/FinancialPlanner.Infrastructure/Authentication/BcryptPasswordHasher.cs
+++ b/FinancialPlanner.Infrastructure/Authentication/BcryptPasswordHasher.cs
@@ -1,0 +1,16 @@
+using FinancialPlanner.Application.Abstractions.Authentication;
+
+namespace FinancialPlanner.Infrastructure.Authentication;
+
+public sealed class BcryptPasswordHasher : IPasswordHasher
+{
+    public string Hash(string password)
+    {
+        return BCrypt.Net.BCrypt.HashPassword(password);
+    }
+
+    public bool Verify(string password, string passwordHash)
+    {
+        return BCrypt.Net.BCrypt.Verify(password, passwordHash);
+    }
+}

--- a/FinancialPlanner.Infrastructure/Authentication/JwtTokenGenerator.cs
+++ b/FinancialPlanner.Infrastructure/Authentication/JwtTokenGenerator.cs
@@ -1,0 +1,44 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using FinancialPlanner.Application.Abstractions.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FinancialPlanner.Infrastructure.Authentication;
+
+public sealed class JwtTokenGenerator(IConfiguration configuration) : IJwtTokenGenerator
+{
+    public string GenerateToken(Guid userId, string email)
+    {
+        var secret = configuration["Jwt:Secret"] ?? throw new InvalidOperationException("JWT secret is not configured.");
+        var issuer = configuration["Jwt:Issuer"] ?? "FinancialPlanner";
+        var audience = configuration["Jwt:Audience"] ?? "FinancialPlanner.Api";
+
+        var claims = new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, email),
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString())
+        };
+
+        var credentials = new SigningCredentials(
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret)),
+            SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer,
+            audience,
+            claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public string GenerateRefreshToken()
+    {
+        return Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
+    }
+}

--- a/FinancialPlanner.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/FinancialPlanner.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using FinancialPlanner.Application.Abstractions.Authentication;
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Infrastructure.Authentication;
+using FinancialPlanner.Infrastructure.Persistence;
+using FinancialPlanner.Infrastructure.Persistence.Repositories;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+
+namespace FinancialPlanner.Infrastructure.DependencyInjection;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string was not found.");
+
+        services.AddDbContext<FinancialPlannerDbContext>(options => options.UseNpgsql(connectionString));
+
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IExpenseRepository, ExpenseRepository>();
+        services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        services.AddSingleton<IJwtTokenGenerator, JwtTokenGenerator>();
+        services.AddSingleton<IPasswordHasher, BcryptPasswordHasher>();
+
+        var secret = configuration["Jwt:Secret"] ?? throw new InvalidOperationException("JWT secret is not configured.");
+        var issuer = configuration["Jwt:Issuer"] ?? "FinancialPlanner";
+        var audience = configuration["Jwt:Audience"] ?? "FinancialPlanner.Api";
+
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.TokenValidationParameters = new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidateAudience = true,
+                    ValidateIssuerSigningKey = true,
+                    ValidateLifetime = true,
+                    ValidIssuer = issuer,
+                    ValidAudience = audience,
+                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret))
+                };
+            });
+
+        services.AddAuthorization();
+
+        return services;
+    }
+}

--- a/FinancialPlanner.Infrastructure/FinancialPlanner.Infrastructure.csproj
+++ b/FinancialPlanner.Infrastructure/FinancialPlanner.Infrastructure.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,6 +9,14 @@
   <ItemGroup>
     <ProjectReference Include="..\FinancialPlanner.Application\FinancialPlanner.Application.csproj" />
     <ProjectReference Include="..\FinancialPlanner.Domain\FinancialPlanner.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 
 </Project>

--- a/FinancialPlanner.Infrastructure/Persistence/Configurations/ExpenseConfiguration.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Configurations/ExpenseConfiguration.cs
@@ -1,0 +1,22 @@
+using FinancialPlanner.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Configurations;
+
+public sealed class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
+{
+    public void Configure(EntityTypeBuilder<Expense> builder)
+    {
+        builder.ToTable("expenses");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserId).HasColumnName("user_id").IsRequired();
+        builder.Property(x => x.Amount).HasColumnName("amount").HasPrecision(18, 2).IsRequired();
+        builder.Property(x => x.Category).HasColumnName("category").HasMaxLength(100).IsRequired();
+        builder.Property(x => x.OccurredAtUtc).HasColumnName("occurred_at_utc").IsRequired();
+        builder.Property(x => x.Note).HasColumnName("note").HasMaxLength(1000);
+
+        builder.HasIndex(x => new { x.UserId, x.OccurredAtUtc });
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Configurations/RefreshTokenConfiguration.cs
@@ -1,0 +1,20 @@
+using FinancialPlanner.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Configurations;
+
+public sealed class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> builder)
+    {
+        builder.ToTable("refresh_tokens");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserId).HasColumnName("user_id").IsRequired();
+        builder.Property(x => x.Token).HasColumnName("token").IsRequired();
+        builder.Property(x => x.ExpiresAtUtc).HasColumnName("expires_at_utc").IsRequired();
+
+        builder.HasIndex(x => x.Token).IsUnique();
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -1,0 +1,26 @@
+using FinancialPlanner.Domain.Entities;
+using FinancialPlanner.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Configurations;
+
+public sealed class UserConfiguration : IEntityTypeConfiguration<User>
+{
+    public void Configure(EntityTypeBuilder<User> builder)
+    {
+        builder.ToTable("users");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Email)
+            .HasConversion(v => v.Value, v => Email.Create(v))
+            .HasColumnName("email")
+            .IsRequired();
+
+        builder.HasIndex(x => x.Email).IsUnique();
+
+        builder.Property(x => x.PasswordHash)
+            .HasColumnName("password_hash")
+            .IsRequired();
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/FinancialPlannerDbContext.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/FinancialPlannerDbContext.cs
@@ -1,0 +1,18 @@
+using FinancialPlanner.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinancialPlanner.Infrastructure.Persistence;
+
+public sealed class FinancialPlannerDbContext(DbContextOptions<FinancialPlannerDbContext> options) : DbContext(options)
+{
+    public DbSet<User> Users => Set<User>();
+
+    public DbSet<Expense> Expenses => Set<Expense>();
+
+    public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(FinancialPlannerDbContext).Assembly);
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/Repositories/ExpenseRepository.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Repositories/ExpenseRepository.cs
@@ -1,0 +1,18 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Repositories;
+
+public sealed class ExpenseRepository(FinancialPlannerDbContext dbContext) : IExpenseRepository
+{
+    public async Task AddAsync(Expense expense, CancellationToken cancellationToken)
+    {
+        await dbContext.Expenses.AddAsync(expense, cancellationToken);
+    }
+
+    public async Task<IReadOnlyCollection<Expense>> ListByUserIdAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        return await dbContext.Expenses.Where(x => x.UserId == userId).ToListAsync(cancellationToken);
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/Repositories/RefreshTokenRepository.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Repositories/RefreshTokenRepository.cs
@@ -1,0 +1,12 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Domain.Entities;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Repositories;
+
+public sealed class RefreshTokenRepository(FinancialPlannerDbContext dbContext) : IRefreshTokenRepository
+{
+    public async Task AddAsync(RefreshToken refreshToken, CancellationToken cancellationToken)
+    {
+        await dbContext.RefreshTokens.AddAsync(refreshToken, cancellationToken);
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/Repositories/UserRepository.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/Repositories/UserRepository.cs
@@ -1,0 +1,23 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+using FinancialPlanner.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinancialPlanner.Infrastructure.Persistence.Repositories;
+
+public sealed class UserRepository(FinancialPlannerDbContext dbContext) : IUserRepository
+{
+    public async Task<User?> GetByEmailAsync(string email, CancellationToken cancellationToken)
+    {
+        return await dbContext.Users.FirstOrDefaultAsync(x => x.Email.Value == email, cancellationToken);
+    }
+
+    public async Task<User?> GetByIdAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        return await dbContext.Users.FirstOrDefaultAsync(x => x.Id == userId, cancellationToken);
+    }
+
+    public async Task AddAsync(User user, CancellationToken cancellationToken)
+    {
+        await dbContext.Users.AddAsync(user, cancellationToken);
+    }
+}

--- a/FinancialPlanner.Infrastructure/Persistence/UnitOfWork.cs
+++ b/FinancialPlanner.Infrastructure/Persistence/UnitOfWork.cs
@@ -1,0 +1,11 @@
+using FinancialPlanner.Application.Abstractions.Persistence;
+
+namespace FinancialPlanner.Infrastructure.Persistence;
+
+public sealed class UnitOfWork(FinancialPlannerDbContext dbContext) : IUnitOfWork
+{
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        return dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# HolofiberFinancePlaner
+# Holofiber Finance Planner
+
+Enterprise-style фінансовий планувальник на базі **ASP.NET Core Web API** з архітектурою **Clean Architecture + CQRS**.
+
+## Структура рішення
+
+- `FinancialPlanner.Domain` — сутності та бізнес-інваріанти.
+- `FinancialPlanner.Application` — CQRS (MediatR), валідація (FluentValidation), абстракції доступу до даних.
+- `FinancialPlanner.Infrastructure` — EF Core/PostgreSQL, JWT, BCrypt, репозиторії, DI-реєстрація.
+- `FinancialPlanner.Api` — контролери, middleware, ProblemDetails, Serilog.
+- `FinancialPlanner.Contracts` — контракти запитів/відповідей для клієнтів.
+
+## Ключові можливості
+
+- JWT автентифікація та refresh-токени.
+- Реєстрація/логін користувача.
+- Створення та читання витрат.
+- Централізована обробка помилок (ProblemDetails).
+- Структуроване логування через Serilog з CorrelationId.
+- Dockerized запуск із PostgreSQL.
+
+## Локальний запуск (Docker)
+
+```bash
+docker compose up --build
+```
+
+API буде доступний на `http://localhost:8080`.
+
+## Налаштування
+
+Конфігурація в `FinancialPlanner.Api/appsettings.json`:
+
+- `ConnectionStrings:DefaultConnection`
+- `Jwt:Secret`
+- `Jwt:Issuer`
+- `Jwt:Audience`
+
+> В production замініть `Jwt:Secret` на довгий випадковий ключ і передавайте через environment variables.
+
+## Наступні кроки
+
+- Додати EF Core migrations.
+- Додати refresh-token rotation та revoke.
+- Покрити Application unit-тестами й API integration-тестами.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__DefaultConnection: Host=postgres;Port=5432;Database=financial_planner;Username=postgres;Password=postgres
+      Jwt__Secret: CHANGE_ME_TO_A_LONG_RANDOM_KEY_AT_LEAST_32_CHARS
+      Jwt__Issuer: FinancialPlanner
+      Jwt__Audience: FinancialPlanner.Api
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: financial_planner
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:


### PR DESCRIPTION
### Motivation

- Provide a complete clean-architecture scaffold for a production-style financial planner (Domain/Application/Infrastructure/Api/Contracts) following SOLID and CQRS principles.
- Implement core auth and expense scenarios (register/login, create/list expenses) with proper domain invariants, validation, and async handlers.
- Add production-ready infra pieces: EF Core/Postgres persistence, JWT + refresh tokens, BCrypt password hashing, logging and error handling, and Docker deployment.

### Description

- Added domain model with entities and value objects enforcing invariants, including `User`, `Expense`, `RefreshToken`, and `Email` under `FinancialPlanner.Domain` and base `Entity` in `FinancialPlanner.Domain.Common`.
- Implemented Application layer CQRS handlers, requests, DTOs and FluentValidation validators with a MediatR validation pipeline behavior in `FinancialPlanner.Application` and added persistence/auth abstractions (`IUserRepository`, `IExpenseRepository`, `IRefreshTokenRepository`, `IUnitOfWork`, `IJwtTokenGenerator`, `IPasswordHasher`).
- Implemented Infrastructure layer: `FinancialPlannerDbContext`, EF Core entity configurations, repository implementations, `UnitOfWork`, `JwtTokenGenerator`, and `BcryptPasswordHasher`, plus DI registration in `FinancialPlanner.Infrastructure` (registered via a reflection-based helper from Application to preserve dependency directions).
- Updated API bootstrap in `FinancialPlanner.Api`: Serilog setup, global exception middleware returning `ProblemDetails` with correlation id, `AuthController` and `ExpensesController` (controllers only orchestrate), `appsettings.json` additions, and project package references for logging and swagger.
- Added Docker support: multi-stage `Dockerfile`, `docker-compose.yml` with Postgres service, and updated `README.md` with run and configuration notes.

### Testing

- Ran `git diff --check` which passed without issues.
- Attempted `dotnet build FinancialPlanner.slnx` but the environment does not have the `dotnet` CLI installed, so a full build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995fece9350832a8ca08a2d0e2ad6ff)